### PR TITLE
Allow passing through of arbitrary data to callback receivers

### DIFF
--- a/contracts/strategies/gmxFrf/GmxFrfStrategyAccount.sol
+++ b/contracts/strategies/gmxFrf/GmxFrfStrategyAccount.sol
@@ -332,12 +332,14 @@ contract GmxFrfStrategyAccount is
      * @param longTokenAmountOut The amount of `asset` to swap for USDC.
      * @param callback           The address of the callback contract that implements `ISwapCallbackHandler.handleSwapCallback`.
      * @param receiver           The address to send `asset` to before executing the callback function.
+     * @param data               Data passed through to the callback contract.
      */
     function executeSwapAssets(
         address market,
         uint256 longTokenAmountOut,
         address callback,
-        address receiver
+        address receiver,
+        bytes memory data
     )
         external
         onlyOwner
@@ -357,7 +359,8 @@ contract GmxFrfStrategyAccount is
             address(this),
             longTokenAmountOut,
             callback,
-            receiver
+            receiver,
+            data
         );
 
         emit SwapAssets(market, longTokenAmountOut, usdcAmountIn);
@@ -394,12 +397,14 @@ contract GmxFrfStrategyAccount is
      * @param amount    The amount of the asset to liquidate.
      * @param callback  The address of the callback contract to call after the liquidation is complete.
      * @param receiever The address to send `asset` to before initiating the callback.
+     * @param data      Data that is passed through to the callback contract.
      */
     function executeLiquidateAssets(
         address asset,
         uint256 amount,
         address callback,
-        address receiever
+        address receiever,
+        bytes memory data
     ) external strategyNonReentrant whenLiquidating hasActiveLoan {
         uint256 usdcAmountIn = SwapCallbackLogic.handleSwapCallback(
             MANAGER,
@@ -407,7 +412,8 @@ contract GmxFrfStrategyAccount is
             amount,
             MANAGER.getAssetLiquidationFeePercent(asset),
             callback,
-            receiever
+            receiever,
+            data
         );
 
         emit LiquidateAssets(msg.sender, asset, amount, usdcAmountIn);
@@ -504,7 +510,8 @@ contract GmxFrfStrategyAccount is
      */
     function executeSwapRebalance(
         address market,
-        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig
+        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig,
+        bytes memory data
     )
         external
         strategyNonReentrant
@@ -517,7 +524,8 @@ contract GmxFrfStrategyAccount is
                 MANAGER,
                 pendingLiquidations_,
                 market,
-                callbackConfig
+                callbackConfig,
+                data
             );
 
         emit SwapRebalancePosition(

--- a/contracts/strategies/gmxFrf/SwapCallbackRelayer.sol
+++ b/contracts/strategies/gmxFrf/SwapCallbackRelayer.sol
@@ -21,15 +21,18 @@ contract SwapCallbackRelayer is ISwapCallbackRelayer {
      * @param callbackHandler   The address of the callback handler.
      * @param tokensToLiquidate The amount of tokens to liquidate during the callback.
      * @param expectedUsdc      The expected USDC received after the callback.
+     * @param data              Data passed through to the callback contract.
      */
     function relaySwapCallback(
         address callbackHandler,
         uint256 tokensToLiquidate,
-        uint256 expectedUsdc
+        uint256 expectedUsdc,
+        bytes memory data
     ) external {
         ISwapCallbackHandler(callbackHandler).handleSwapCallback(
             tokensToLiquidate,
-            expectedUsdc
+            expectedUsdc,
+            data
         );
     }
 }

--- a/contracts/strategies/gmxFrf/interfaces/IGmxFrfStrategyAccount.sol
+++ b/contracts/strategies/gmxFrf/interfaces/IGmxFrfStrategyAccount.sol
@@ -265,14 +265,13 @@ interface IGmxFrfStrategyAccount is IStrategyAccount {
         );
 
     /// @dev Allows the account owner to sell assets for USDC in order to repay theirloan.
-     function executeSwapAssets(
+    function executeSwapAssets(
         address market,
         uint256 longTokenAmountOut,
         address callback,
         address receiver,
         bytes memory data
-    )
-        external;
+    ) external;
 
     /// @dev Call multiple methods in a single transaction without the need of a contract.
     function multicall(

--- a/contracts/strategies/gmxFrf/interfaces/IGmxFrfStrategyAccount.sol
+++ b/contracts/strategies/gmxFrf/interfaces/IGmxFrfStrategyAccount.sol
@@ -215,7 +215,8 @@ interface IGmxFrfStrategyAccount is IStrategyAccount {
         address asset,
         uint256 amount,
         address callback,
-        address receiever
+        address receiever,
+        bytes memory data
     ) external;
 
     /// @dev Liquidate a position by creating an order to reduce the position's size.  Non-atomic.
@@ -247,7 +248,8 @@ interface IGmxFrfStrategyAccount is IStrategyAccount {
     /// @dev Rebalanec a position with
     function executeSwapRebalance(
         address market,
-        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig
+        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig,
+        bytes memory data
     ) external;
 
     /// @dev Rebalance a position that is outside of the configured delta range. Callable by anyone. The caller recieves a fee for their service.  Non-atomic.
@@ -261,6 +263,16 @@ interface IGmxFrfStrategyAccount is IStrategyAccount {
             IGmxV2OrderTypes.CreateOrderParams memory order,
             bytes32 orderKey
         );
+
+    /// @dev Allows the account owner to sell assets for USDC in order to repay theirloan.
+     function executeSwapAssets(
+        address market,
+        uint256 longTokenAmountOut,
+        address callback,
+        address receiver,
+        bytes memory data
+    )
+        external;
 
     /// @dev Call multiple methods in a single transaction without the need of a contract.
     function multicall(

--- a/contracts/strategies/gmxFrf/interfaces/ISwapCallbackHandler.sol
+++ b/contracts/strategies/gmxFrf/interfaces/ISwapCallbackHandler.sol
@@ -15,6 +15,7 @@ interface ISwapCallbackHandler {
     /// @dev Handle a swap callback.
     function handleSwapCallback(
         uint256 tokensToLiquidate,
-        uint256 expectedUsdc
+        uint256 expectedUsdc,
+        bytes memory data
     ) external;
 }

--- a/contracts/strategies/gmxFrf/interfaces/ISwapCallbackRelayer.sol
+++ b/contracts/strategies/gmxFrf/interfaces/ISwapCallbackRelayer.sol
@@ -19,6 +19,7 @@ interface ISwapCallbackRelayer {
     function relaySwapCallback(
         address callbackHandler,
         uint256 tokensToLiquidate,
-        uint256 expectedUsdc
+        uint256 expectedUsdc,
+        bytes memory data
     ) external;
 }

--- a/contracts/strategies/gmxFrf/libraries/LiquidationLogic.sol
+++ b/contracts/strategies/gmxFrf/libraries/LiquidationLogic.sol
@@ -63,6 +63,7 @@ library LiquidationLogic {
      * @param pendingLiquidations_ The pending liquidations that will be canceled for the position.
      * @param market               The market to rebalance. This will be used to determine the token to sell.
      * @param callbackConfig       The callback configuration for the liquidation. At least `expectedUSDC` must be returned to the contract, otherwise the call will revert.
+     * @param data                 Data passed through to the callback contract.
      * @return rebalanceAmount     The amount of tokens sent out of the contract to be swapped for USDC.
      * @return usdcAmountIn        The callback configuration for the liquidation. At least `expectedUSDC` must be returned to the contract, otherwise the call will revert.
      */
@@ -71,7 +72,8 @@ library LiquidationLogic {
         mapping(bytes32 => OrderLogic.PendingLiquidation)
             storage pendingLiquidations_,
         address market,
-        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig
+        IGmxFrfStrategyAccount.CallbackConfig memory callbackConfig,
+        bytes memory data
     ) external returns (uint256 rebalanceAmount, uint256 usdcAmountIn) {
         IGmxV2DataStore dataStore = manager.gmxV2DataStore();
 
@@ -158,17 +160,22 @@ library LiquidationLogic {
             );
         }
 
-        // Call the liquidation callback handler.
-        return (
-            rebalanceAmount,
-            SwapCallbackLogic.handleSwapCallback(
+        {
+            usdcAmountIn = SwapCallbackLogic.handleSwapCallback(
                 manager,
                 longToken,
                 rebalanceAmount,
                 manager.getAssetLiquidationFeePercent(longToken),
                 callbackConfig.callback,
-                callbackConfig.receiever
-            )
+                callbackConfig.receiever,
+                data
+            );
+        }
+
+        // Call the liquidation callback handler.
+        return (
+            rebalanceAmount,
+            usdcAmountIn
         );
     }
 

--- a/contracts/strategies/gmxFrf/libraries/LiquidationLogic.sol
+++ b/contracts/strategies/gmxFrf/libraries/LiquidationLogic.sol
@@ -173,10 +173,7 @@ library LiquidationLogic {
         }
 
         // Call the liquidation callback handler.
-        return (
-            rebalanceAmount,
-            usdcAmountIn
-        );
+        return (rebalanceAmount, usdcAmountIn);
     }
 
     /**

--- a/contracts/strategies/gmxFrf/libraries/SwapCallbackLogic.sol
+++ b/contracts/strategies/gmxFrf/libraries/SwapCallbackLogic.sol
@@ -34,6 +34,7 @@ library SwapCallbackLogic {
      * @param callback           The callback that will be called to handle the swap. This must implement the `ISwapCallbackHandler` interface and return the expected USDC amount
      * after execution finishes.
      * @param tokenReceiever    The address that should recieve the `asset` being swapped.
+     * @param data              Data passed through to the callback contract.
      * @return usdcAmountIn     The amount of USDC received back after the callback.
      */
     function handleSwapCallback(
@@ -42,7 +43,8 @@ library SwapCallbackLogic {
         uint256 amount,
         uint256 maxSlippagePercent,
         address callback,
-        address tokenReceiever
+        address tokenReceiever,
+        bytes memory data
     ) public returns (uint256 usdcAmountIn) {
         IERC20 usdc = manager.USDC();
 
@@ -85,7 +87,8 @@ library SwapCallbackLogic {
         manager.SWAP_CALLBACK_RELAYER().relaySwapCallback(
             callback,
             amount,
-            minimumUSDCRecieved
+            minimumUSDCRecieved,
+            data
         );
 
         usdcAmountIn = usdc.balanceOf(address(this)) - balanceUSDCBefore;

--- a/contracts/strategies/gmxFrf/libraries/WithdrawalLogic.sol
+++ b/contracts/strategies/gmxFrf/libraries/WithdrawalLogic.sol
@@ -155,6 +155,7 @@ library WithdrawalLogic {
      * @param callback           The address of the callback handler. This address must be a smart contract that implements the
      * `ISwapCallbackHandler` interface.
      * @param receiver           The address that the `longToken` should be sent to.
+     * @param data               Data passed through to the callback contract.
      */
     function swapTokensForUSDC(
         IGmxFrfStrategyManager manager,
@@ -162,7 +163,8 @@ library WithdrawalLogic {
         address account,
         uint256 longTokenAmountOut,
         address callback,
-        address receiver
+        address receiver,
+        bytes memory data
     ) external returns (uint256 amountReceived) {
         // Return early if amount is zero.
         if (longTokenAmountOut == 0) {
@@ -189,7 +191,8 @@ library WithdrawalLogic {
                 longTokenAmountOut,
                 marketConfig.orderPricingParameters.maxSwapSlippagePercent,
                 callback,
-                receiver
+                receiver,
+                data
             );
     }
 

--- a/tests/strategies/gmxFrf/GmxStrategyForkTests.t.sol
+++ b/tests/strategies/gmxFrf/GmxStrategyForkTests.t.sol
@@ -561,7 +561,8 @@ contract GmxStrategyForkTests is
         vm.expectRevert();
         etched.executeSwapRebalance(
             GmxFrfStrategyMetadata.GMX_V2_ARB_USDC_MARKET,
-            callbackConfig
+            callbackConfig,
+            new bytes(0)
         );
     }
 
@@ -576,7 +577,8 @@ contract GmxStrategyForkTests is
         vm.expectRevert();
         etched.executeSwapRebalance(
             GmxFrfStrategyMetadata.GMX_V2_ETH_USDC,
-            callbackConfig
+            callbackConfig,
+            new bytes(0)
         );
     }
 
@@ -591,7 +593,8 @@ contract GmxStrategyForkTests is
         vm.expectRevert();
         etched.executeSwapRebalance(
             GmxFrfStrategyMetadata.GMX_V2_WBTC_USDC_MARKET,
-            callbackConfig
+            callbackConfig,
+            new bytes(0)
         );
     }
 
@@ -614,7 +617,8 @@ contract GmxStrategyForkTests is
         vm.expectRevert();
         etched.executeSwapRebalance(
             GmxFrfStrategyMetadata.GMX_V2_ARB_USDC_MARKET,
-            callbackConfig
+            callbackConfig,
+            new bytes(0)
         );
     }
 
@@ -628,7 +632,8 @@ contract GmxStrategyForkTests is
 
         etched.executeSwapRebalance(
             GmxFrfStrategyMetadata.GMX_V2_ARB_USDC_MARKET,
-            callbackConfig
+            callbackConfig,
+            new bytes(0)
         );
     }
 


### PR DESCRIPTION
This is required to properly allow for the `executeSwapAssets` function to work, since the `ownable` modifier prevents a callback contract from caching swap information and then subsequently calling `executeSwapAssets`.

This also simplifies the logic for callback contracts that integrate with rebalance and liquidation swap methods,
as it does not require storage caching of swap information before interacting with the strategy account.